### PR TITLE
Lua 5.3 compatibility: addition also of luaL_optlong define

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -117,6 +117,7 @@ typedef SIZE_T		ULONG_PTR, DWORD_PTR;
 #ifndef luaL_checkint
 #define luaL_checkint(L,n)	((int)luaL_checkinteger(L, (n)))
 #define luaL_optint(L,n,d)	((int)luaL_optinteger(L, (n), (d)))
+#define luaL_optlong(L,n,d)	((long)luaL_optinteger(L, (n), (d)))
 #endif
 
 


### PR DESCRIPTION
Additional change needed for luasys to work with Lua 5.3 (similar to ones already done in 9a916b6104f8f990cac2f336990fec068be1a604)