### PR TITLE
Remove usage of sys/sysctl.h (deprecated) in non-BSD builds

### DIFF
--- a/src/luasys.c
+++ b/src/luasys.c
@@ -10,7 +10,9 @@
 #include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <sys/resource.h>
+#if defined(BSD)
 #include <sys/sysctl.h>
+#endif
 
 #define SYS_FILE_PERMISSIONS	0644  /* default file permissions */
 


### PR DESCRIPTION
The header file sys/sysctl.h is deprecated in Linux from some time.
This means that a warning is now issued that may break the build if
error on warnings is enabled. In the future, as the header gets
removed, this will be directly an error.
It seems that we still need for now this in BSD as sysctl is used
to get the number of processors, so confine the usage of such header
to BSD builds via ifdef.

Signed-off-by: Federico Pellegrin <fede@evolware.org>