### PR TITLE
Lua 5.4.x support

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -104,6 +104,12 @@ typedef SIZE_T		ULONG_PTR, DWORD_PTR;
     ((idx) < 0 && (idx) > -99 ? lua_gettop(L) + (idx) + 1 : (idx))
 
 #else
+
+#if LUA_VERSION_NUM >= 504
+static int nresultsResume;
+#define lua_resume(L,from,n)	lua_resume(L,from,n,&nresultsResume)
+#endif
+
 #define luaL_register(L,n,l)	luaL_newlib((L), (l))
 #define lua_setfenv		lua_setuservalue
 #define lua_getfenv		lua_getuservalue

--- a/src/thread/sys_thread.c
+++ b/src/thread/sys_thread.c
@@ -368,7 +368,10 @@ static const char *const stdlib_names[] = {
   LUA_TABLIBNAME, LUA_IOLIBNAME, LUA_OSLIBNAME,
   LUA_STRLIBNAME, LUA_MATHLIBNAME, LUA_DBLIBNAME,
 #if LUA_VERSION_NUM >= 502
-  LUA_COLIBNAME, LUA_BITLIBNAME,
+  LUA_COLIBNAME,
+#endif
+#if (LUA_VERSION_NUM >= 502) && (LUA_VERSION_NUM < 504)
+  LUA_BITLIBNAME,
 #endif
 #ifdef LUA_JITLIBNAME
   LUA_JITLIBNAME, LUA_BITLIBNAME, LUA_FFILIBNAME,
@@ -379,7 +382,10 @@ static const lua_CFunction stdlib_funcs[] = {
   luaopen_table, luaopen_io, luaopen_os,
   luaopen_string, luaopen_math, luaopen_debug,
 #if LUA_VERSION_NUM >= 502
-  luaopen_coroutine, luaopen_bit32,
+  luaopen_coroutine,
+#endif
+#if (LUA_VERSION_NUM >= 502) && (LUA_VERSION_NUM < 504)
+ luaopen_bit32,
 #endif
 #ifdef LUA_JITLIBNAME
   luaopen_jit, luaopen_bit, luaopen_ffi


### PR DESCRIPTION
Consist of two patches:
- Remove usage of now removed (previously deprecated) 32-bit files when using Lua 5.4
- Fix changed (breaking) API for `lua_resume` when using Lua 5.4